### PR TITLE
tweak: tweak dialog

### DIFF
--- a/vendor/assets/javascripts/ckeditor/plugins/link/dialogs/link.js
+++ b/vendor/assets/javascripts/ckeditor/plugins/link/dialogs/link.js
@@ -381,6 +381,15 @@
 				var selection = editor.getSelection(),
 					attributes = plugin.getLinkAttributes( editor, data );
 
+				// fix link target when both have url and document tab in same dialog
+				var isLinkOpenInNewTab = data.type === 'url' && data.web.openInNewTab
+				var isDocumentOpenInNewTab = data.type === 'document' && data.document.openInNewTab
+				if (isLinkOpenInNewTab || isDocumentOpenInNewTab) {
+					attributes.set.target = '_blank'
+				} else {
+					attributes.set.target = '_self'
+				}
+
 				if (data.type === 'email' && !data.email.address || data.type === 'url' && !data.web.url || data.type === 'document' && !data.document.url) {
 					editor.execCommand('unlink');
 					return;


### PR DESCRIPTION
 ckeditor 链接点击弹出框，如果同时包含 link 和 document 两个 openInNewTab  的 checkbox, 这两个会相互影响
即当 `data.document.openInNewTab = true`  且 `data.web.openInNewTab = false` 时， 此时错误的获取 link 的 `target = '_blank'`

修复方法: 在添加 link element 的方法中新增一个调整函数

<img width="1094" alt="wx20190220-103543 2x" src="https://user-images.githubusercontent.com/14243932/53065144-665d2600-3505-11e9-9803-8e1607a55adb.png">
